### PR TITLE
Add propstack task creation to signup

### DIFF
--- a/assets/js/panel.js
+++ b/assets/js/panel.js
@@ -6,10 +6,13 @@ jQuery(document).ready(function ($) {
     console.log("CF7 Propstack: No nonce found, exiting");
     return;
   }
-  
+
   console.log("CF7 Propstack: panel.js initialized successfully");
-  console.log("CF7 Propstack: Test API button exists:", $("#test_properties_api").length);
-  console.log("CF7 Propstack: Refresh buttons exist:", $("#refresh_properties").length, $("#refresh_client_sources").length);
+  console.log(
+    "CF7 Propstack: Refresh buttons exist:",
+    $("#refresh_projects").length,
+    $("#refresh_client_sources").length
+  );
 
   // Function to update CF7 field dropdown to disable already mapped fields
   function updateCF7FieldDropdown() {
@@ -234,20 +237,25 @@ jQuery(document).ready(function ($) {
     }, 3000);
   }
 
-  // Handle refresh properties button
-  $(document).on("click", "#refresh_properties", function (e) {
-    console.log("CF7 Propstack: Refresh properties button clicked");
+  // Handle refresh projects button
+  $(document).on("click", "#refresh_projects", function (e) {
+    console.log("CF7 Propstack: Refresh projects button clicked");
     e.preventDefault();
 
     var button = $(this);
     var originalText = button.text();
-    button.text(window.cf7PropstackPanelL10n?.refreshingText || "Refreshing...").prop("disabled", true);
+    button
+      .text(window.cf7PropstackPanelL10n?.refreshingText || "Refreshing...")
+      .prop("disabled", true);
 
     var nonce = $("#cf7_propstack_nonce").val();
     var ajaxUrl = $("#cf7_propstack_ajax_url").val();
 
     if (!nonce || !ajaxUrl) {
-      alert(window.cf7PropstackPanelL10n?.missingNonceText || "Missing nonce or AJAX URL. Please refresh the page.");
+      alert(
+        window.cf7PropstackPanelL10n?.missingNonceText ||
+          "Missing nonce or AJAX URL. Please refresh the page."
+      );
       button.text(originalText).prop("disabled", false);
       return;
     }
@@ -257,24 +265,24 @@ jQuery(document).ready(function ($) {
       type: "POST",
       dataType: "json",
       data: {
-        action: "refresh_properties",
+        action: "refresh_projects",
         nonce: nonce,
       },
       success: function (response) {
-        console.log("CF7 Propstack: Refresh properties success:", response);
-        if (response.success && response.data.properties) {
-          var select = $("#wpcf7-propstack-property-id");
+        console.log("CF7 Propstack: Refresh projects success:", response);
+        if (response.success && response.data.projects) {
+          var select = $("#wpcf7-propstack-project-id");
           var selectedValue = select.val();
 
           // Clear existing options except the first one
           select.find("option:not(:first)").remove();
 
           // Add new options
-          $.each(response.data.properties, function (index, property) {
+          $.each(response.data.projects, function (index, project) {
             var title =
-              property.title || property.name || "Property #" + property.id;
+              project.title || project.name || "Project #" + project.id;
             select.append(
-              '<option value="' + property.id + '">' + title + "</option>"
+              '<option value="' + project.id + '">' + title + "</option>"
             );
           });
 
@@ -282,16 +290,25 @@ jQuery(document).ready(function ($) {
           select.val(selectedValue);
 
           showMessage(
-            response.data.message || window.cf7PropstackPanelL10n?.propertiesRefreshedText || "Properties refreshed successfully!",
+            response.data.message ||
+              window.cf7PropstackPanelL10n?.projectsRefreshedText ||
+              "Projects refreshed successfully!",
             "success"
           );
         } else {
-          alert(response.data || window.cf7PropstackPanelL10n?.failedRefreshPropertiesText || "Failed to refresh properties.");
+          alert(
+            response.data ||
+              window.cf7PropstackPanelL10n?.failedRefreshProjectsText ||
+              "Failed to refresh projects."
+          );
         }
       },
       error: function (xhr, status, error) {
-        console.log("CF7 Propstack: Refresh properties error:", status, error);
-        alert(window.cf7PropstackPanelL10n?.errorRefreshText || "Error refreshing properties. Please try again.");
+        console.log("CF7 Propstack: Refresh projects error:", status, error);
+        alert(
+          window.cf7PropstackPanelL10n?.errorRefreshText ||
+            "Error refreshing projects. Please try again."
+        );
       },
       complete: function () {
         button.text(originalText).prop("disabled", false);
@@ -306,13 +323,18 @@ jQuery(document).ready(function ($) {
 
     var button = $(this);
     var originalText = button.text();
-    button.text(window.cf7PropstackPanelL10n?.refreshingText || "Refreshing...").prop("disabled", true);
+    button
+      .text(window.cf7PropstackPanelL10n?.refreshingText || "Refreshing...")
+      .prop("disabled", true);
 
     var nonce = $("#cf7_propstack_nonce").val();
     var ajaxUrl = $("#cf7_propstack_ajax_url").val();
 
     if (!nonce || !ajaxUrl) {
-      alert(window.cf7PropstackPanelL10n?.missingNonceText || "Missing nonce or AJAX URL. Please refresh the page.");
+      alert(
+        window.cf7PropstackPanelL10n?.missingNonceText ||
+          "Missing nonce or AJAX URL. Please refresh the page."
+      );
       button.text(originalText).prop("disabled", false);
       return;
     }
@@ -346,75 +368,29 @@ jQuery(document).ready(function ($) {
           select.val(selectedValue);
 
           showMessage(
-            response.data.message || window.cf7PropstackPanelL10n?.clientSourcesRefreshedText || "Client sources refreshed successfully!",
+            response.data.message ||
+              window.cf7PropstackPanelL10n?.clientSourcesRefreshedText ||
+              "Client sources refreshed successfully!",
             "success"
           );
         } else {
-          alert(response.data || window.cf7PropstackPanelL10n?.failedRefreshClientSourcesText || "Failed to refresh client sources.");
-        }
-      },
-      error: function (xhr, status, error) {
-        console.log("CF7 Propstack: Refresh client sources error:", status, error);
-        alert(window.cf7PropstackPanelL10n?.errorRefreshText || "Error refreshing client sources. Please try again.");
-      },
-      complete: function () {
-        button.text(originalText).prop("disabled", false);
-      },
-    });
-  });
-
-  // Handle test properties API button
-  $(document).on("click", "#test_properties_api", function (e) {
-    console.log("CF7 Propstack: Test API button clicked");
-    e.preventDefault();
-
-    var button = $(this);
-    var originalText = button.text();
-    var nonce = $("#cf7_propstack_nonce").val();
-    var ajaxUrl = $("#cf7_propstack_ajax_url").val();
-
-    console.log("CF7 Propstack: Test API - nonce:", nonce, "ajaxUrl:", ajaxUrl);
-
-    if (!nonce || !ajaxUrl) {
-      alert(window.cf7PropstackPanelL10n?.missingNonceText || "Missing nonce or AJAX URL. Please refresh the page.");
-      return;
-    }
-
-    button.text(window.cf7PropstackPanelL10n?.testingText || "Testing...").prop("disabled", true);
-
-    $.ajax({
-      url: ajaxUrl,
-      type: "POST",
-      dataType: "json",
-      data: {
-        action: "test_properties_api",
-        nonce: nonce,
-      },
-      success: function (response) {
-        console.log("CF7 Propstack: Test API success response:", response);
-        if (response.success && response.data.debug_info) {
-          var info = response.data.debug_info;
-          var message = "API Test Results:\n\n";
-          message +=
-            "API Key Configured: " + (info.api_key_configured ? "Yes" : "No") + "\n";
-          message += "Response Type: " + info.response_type + "\n";
-          message += "Response Count: " + info.response_count + "\n";
-          message +=
-            "Raw Response: " + JSON.stringify(info.api_response, null, 2);
-
-          alert(message);
-        } else {
-          alert(response.data || window.cf7PropstackPanelL10n?.testFailedText || "Test failed.");
+          alert(
+            response.data ||
+              window.cf7PropstackPanelL10n?.failedRefreshClientSourcesText ||
+              "Failed to refresh client sources."
+          );
         }
       },
       error: function (xhr, status, error) {
         console.log(
-          "CF7 Propstack: Test API AJAX error:",
+          "CF7 Propstack: Refresh client sources error:",
           status,
-          error,
-          xhr.responseText
+          error
         );
-        alert(window.cf7PropstackPanelL10n?.errorTestText || "Error testing API. Please try again.");
+        alert(
+          window.cf7PropstackPanelL10n?.errorRefreshText ||
+            "Error refreshing client sources. Please try again."
+        );
       },
       complete: function () {
         button.text(originalText).prop("disabled", false);
@@ -435,7 +411,10 @@ jQuery(document).ready(function ($) {
     var ajaxUrl = $("#cf7_propstack_ajax_url").val();
 
     if (!nonce || !ajaxUrl) {
-      alert(window.cf7PropstackPanelL10n?.missingNonceText || "Missing nonce or AJAX URL. Please refresh the page.");
+      alert(
+        window.cf7PropstackPanelL10n?.missingNonceText ||
+          "Missing nonce or AJAX URL. Please refresh the page."
+      );
       button.text(originalText).prop("disabled", false);
       return;
     }
@@ -456,7 +435,7 @@ jQuery(document).ready(function ($) {
             "success"
           );
           // Reload the page to show fresh data
-          setTimeout(function() {
+          setTimeout(function () {
             location.reload();
           }, 1000);
         } else {

--- a/assets/js/panel.js
+++ b/assets/js/panel.js
@@ -2,7 +2,14 @@ console.log("CF7 Propstack panel.js loaded");
 
 jQuery(document).ready(function ($) {
   // Only run on the CF7 Propstack panel
-  if (!document.getElementById("cf7_propstack_nonce")) return;
+  if (!document.getElementById("cf7_propstack_nonce")) {
+    console.log("CF7 Propstack: No nonce found, exiting");
+    return;
+  }
+  
+  console.log("CF7 Propstack: panel.js initialized successfully");
+  console.log("CF7 Propstack: Test API button exists:", $("#test_properties_api").length);
+  console.log("CF7 Propstack: Refresh buttons exist:", $("#refresh_properties").length, $("#refresh_client_sources").length);
 
   // Function to update CF7 field dropdown to disable already mapped fields
   function updateCF7FieldDropdown() {
@@ -226,4 +233,243 @@ jQuery(document).ready(function ($) {
       });
     }, 3000);
   }
+
+  // Handle refresh properties button
+  $(document).on("click", "#refresh_properties", function (e) {
+    console.log("CF7 Propstack: Refresh properties button clicked");
+    e.preventDefault();
+
+    var button = $(this);
+    var originalText = button.text();
+    button.text(window.cf7PropstackPanelL10n?.refreshingText || "Refreshing...").prop("disabled", true);
+
+    var nonce = $("#cf7_propstack_nonce").val();
+    var ajaxUrl = $("#cf7_propstack_ajax_url").val();
+
+    if (!nonce || !ajaxUrl) {
+      alert(window.cf7PropstackPanelL10n?.missingNonceText || "Missing nonce or AJAX URL. Please refresh the page.");
+      button.text(originalText).prop("disabled", false);
+      return;
+    }
+
+    $.ajax({
+      url: ajaxUrl,
+      type: "POST",
+      dataType: "json",
+      data: {
+        action: "refresh_properties",
+        nonce: nonce,
+      },
+      success: function (response) {
+        console.log("CF7 Propstack: Refresh properties success:", response);
+        if (response.success && response.data.properties) {
+          var select = $("#wpcf7-propstack-property-id");
+          var selectedValue = select.val();
+
+          // Clear existing options except the first one
+          select.find("option:not(:first)").remove();
+
+          // Add new options
+          $.each(response.data.properties, function (index, property) {
+            var title =
+              property.title || property.name || "Property #" + property.id;
+            select.append(
+              '<option value="' + property.id + '">' + title + "</option>"
+            );
+          });
+
+          // Restore selected value if it still exists
+          select.val(selectedValue);
+
+          showMessage(
+            response.data.message || window.cf7PropstackPanelL10n?.propertiesRefreshedText || "Properties refreshed successfully!",
+            "success"
+          );
+        } else {
+          alert(response.data || window.cf7PropstackPanelL10n?.failedRefreshPropertiesText || "Failed to refresh properties.");
+        }
+      },
+      error: function (xhr, status, error) {
+        console.log("CF7 Propstack: Refresh properties error:", status, error);
+        alert(window.cf7PropstackPanelL10n?.errorRefreshText || "Error refreshing properties. Please try again.");
+      },
+      complete: function () {
+        button.text(originalText).prop("disabled", false);
+      },
+    });
+  });
+
+  // Handle refresh client sources button
+  $(document).on("click", "#refresh_client_sources", function (e) {
+    console.log("CF7 Propstack: Refresh client sources button clicked");
+    e.preventDefault();
+
+    var button = $(this);
+    var originalText = button.text();
+    button.text(window.cf7PropstackPanelL10n?.refreshingText || "Refreshing...").prop("disabled", true);
+
+    var nonce = $("#cf7_propstack_nonce").val();
+    var ajaxUrl = $("#cf7_propstack_ajax_url").val();
+
+    if (!nonce || !ajaxUrl) {
+      alert(window.cf7PropstackPanelL10n?.missingNonceText || "Missing nonce or AJAX URL. Please refresh the page.");
+      button.text(originalText).prop("disabled", false);
+      return;
+    }
+
+    $.ajax({
+      url: ajaxUrl,
+      type: "POST",
+      dataType: "json",
+      data: {
+        action: "refresh_client_sources",
+        nonce: nonce,
+      },
+      success: function (response) {
+        console.log("CF7 Propstack: Refresh client sources success:", response);
+        if (response.success && response.data.client_sources) {
+          var select = $("#wpcf7-propstack-client-source-id");
+          var selectedValue = select.val();
+
+          // Clear existing options except the first one
+          select.find("option:not(:first)").remove();
+
+          // Add new options
+          $.each(response.data.client_sources, function (index, source) {
+            var name = source.name || source.title || "Source #" + source.id;
+            select.append(
+              '<option value="' + source.id + '">' + name + "</option>"
+            );
+          });
+
+          // Restore selected value if it still exists
+          select.val(selectedValue);
+
+          showMessage(
+            response.data.message || window.cf7PropstackPanelL10n?.clientSourcesRefreshedText || "Client sources refreshed successfully!",
+            "success"
+          );
+        } else {
+          alert(response.data || window.cf7PropstackPanelL10n?.failedRefreshClientSourcesText || "Failed to refresh client sources.");
+        }
+      },
+      error: function (xhr, status, error) {
+        console.log("CF7 Propstack: Refresh client sources error:", status, error);
+        alert(window.cf7PropstackPanelL10n?.errorRefreshText || "Error refreshing client sources. Please try again.");
+      },
+      complete: function () {
+        button.text(originalText).prop("disabled", false);
+      },
+    });
+  });
+
+  // Handle test properties API button
+  $(document).on("click", "#test_properties_api", function (e) {
+    console.log("CF7 Propstack: Test API button clicked");
+    e.preventDefault();
+
+    var button = $(this);
+    var originalText = button.text();
+    var nonce = $("#cf7_propstack_nonce").val();
+    var ajaxUrl = $("#cf7_propstack_ajax_url").val();
+
+    console.log("CF7 Propstack: Test API - nonce:", nonce, "ajaxUrl:", ajaxUrl);
+
+    if (!nonce || !ajaxUrl) {
+      alert(window.cf7PropstackPanelL10n?.missingNonceText || "Missing nonce or AJAX URL. Please refresh the page.");
+      return;
+    }
+
+    button.text(window.cf7PropstackPanelL10n?.testingText || "Testing...").prop("disabled", true);
+
+    $.ajax({
+      url: ajaxUrl,
+      type: "POST",
+      dataType: "json",
+      data: {
+        action: "test_properties_api",
+        nonce: nonce,
+      },
+      success: function (response) {
+        console.log("CF7 Propstack: Test API success response:", response);
+        if (response.success && response.data.debug_info) {
+          var info = response.data.debug_info;
+          var message = "API Test Results:\n\n";
+          message +=
+            "API Key Configured: " + (info.api_key_configured ? "Yes" : "No") + "\n";
+          message += "Response Type: " + info.response_type + "\n";
+          message += "Response Count: " + info.response_count + "\n";
+          message +=
+            "Raw Response: " + JSON.stringify(info.api_response, null, 2);
+
+          alert(message);
+        } else {
+          alert(response.data || window.cf7PropstackPanelL10n?.testFailedText || "Test failed.");
+        }
+      },
+      error: function (xhr, status, error) {
+        console.log(
+          "CF7 Propstack: Test API AJAX error:",
+          status,
+          error,
+          xhr.responseText
+        );
+        alert(window.cf7PropstackPanelL10n?.errorTestText || "Error testing API. Please try again.");
+      },
+      complete: function () {
+        button.text(originalText).prop("disabled", false);
+      },
+    });
+  });
+
+  // Handle clear cache button
+  $(document).on("click", "#clear_propstack_cache", function (e) {
+    console.log("CF7 Propstack: Clear cache button clicked");
+    e.preventDefault();
+
+    var button = $(this);
+    var originalText = button.text();
+    button.text("Clearing...").prop("disabled", true);
+
+    var nonce = $("#cf7_propstack_nonce").val();
+    var ajaxUrl = $("#cf7_propstack_ajax_url").val();
+
+    if (!nonce || !ajaxUrl) {
+      alert(window.cf7PropstackPanelL10n?.missingNonceText || "Missing nonce or AJAX URL. Please refresh the page.");
+      button.text(originalText).prop("disabled", false);
+      return;
+    }
+
+    $.ajax({
+      url: ajaxUrl,
+      type: "POST",
+      dataType: "json",
+      data: {
+        action: "clear_propstack_cache",
+        nonce: nonce,
+      },
+      success: function (response) {
+        console.log("CF7 Propstack: Clear cache success:", response);
+        if (response.success) {
+          showMessage(
+            response.data.message || "Cache cleared successfully!",
+            "success"
+          );
+          // Reload the page to show fresh data
+          setTimeout(function() {
+            location.reload();
+          }, 1000);
+        } else {
+          alert(response.data || "Failed to clear cache.");
+        }
+      },
+      error: function (xhr, status, error) {
+        console.log("CF7 Propstack: Clear cache error:", status, error);
+        alert("Error clearing cache. Please try again.");
+      },
+      complete: function () {
+        button.text(originalText).prop("disabled", false);
+      },
+    });
+  });
 });

--- a/includes/class-propstack-api.php
+++ b/includes/class-propstack-api.php
@@ -25,6 +25,10 @@ class CF7_Propstack_API
         $this->api_key = isset($options['api_key']) ? $options['api_key'] : '';
         $this->api_url = 'https://api.propstack.de/v1';
         $this->debug_mode = isset($options['debug_mode']) ? $options['debug_mode'] : false;
+        
+        // Debug log for troubleshooting
+        error_log('[CF7 Propstack] API Constructor - API Key configured: ' . (!empty($this->api_key) ? 'Yes' : 'No'));
+        error_log('[CF7 Propstack] API Constructor - Debug mode: ' . ($this->debug_mode ? 'Yes' : 'No'));
     }
 
     /**
@@ -170,18 +174,50 @@ class CF7_Propstack_API
     public function get_properties()
     {
         if (empty($this->api_key)) {
-            $this->log_error('API key not configured');
+            $this->debug_log('API key not configured for properties');
             return array();
         }
 
-        $endpoint = $this->api_url . '/units';
+        // Try the datadump endpoint first, then fallback to units
+        $endpoints = array(
+            $this->api_url . '/datadump/properties',
+            $this->api_url . '/units',
+            $this->api_url . '/properties'
+        );
 
-        $response = $this->make_request('GET', $endpoint);
+        $response = null;
+        $successful_endpoint = null;
 
-        if ($response && is_array($response)) {
-            return $response;
+        foreach ($endpoints as $endpoint) {
+            $this->debug_log('Attempting to fetch properties from: ' . $endpoint);
+            $response = $this->make_request('GET', $endpoint);
+            
+            if ($response) {
+                $successful_endpoint = $endpoint;
+                $this->debug_log('Successfully got response from: ' . $endpoint);
+                break;
+            } else {
+                $this->debug_log('No response from: ' . $endpoint);
+            }
         }
 
+        $this->debug_log('Properties API response: ' . json_encode($response));
+
+        if ($response) {
+            // Handle different response formats
+            if (is_array($response)) {
+                $this->debug_log('Properties fetched successfully: ' . count($response) . ' properties');
+                return $response;
+            } elseif (isset($response['data']) && is_array($response['data'])) {
+                $this->debug_log('Properties fetched from data field: ' . count($response['data']) . ' properties');
+                return $response['data'];
+            } elseif (isset($response['units']) && is_array($response['units'])) {
+                $this->debug_log('Properties fetched from units field: ' . count($response['units']) . ' properties');
+                return $response['units'];
+            }
+        }
+
+        $this->debug_log('Properties response was not in expected format or was empty');
         return array();
     }
 
@@ -312,6 +348,22 @@ class CF7_Propstack_API
         }
 
         error_log('[CF7 Propstack] SUCCESS: ' . $message);
+    }
+
+    /**
+     * Debug log messages (always logs regardless of debug mode)
+     */
+    private function debug_log($message)
+    {
+        error_log('[CF7 Propstack] DEBUG: ' . $message);
+    }
+
+    /**
+     * Check if API key is configured
+     */
+    public function is_api_key_configured()
+    {
+        return !empty($this->api_key);
     }
 
     /**

--- a/includes/class-propstack-api.php
+++ b/includes/class-propstack-api.php
@@ -165,6 +165,54 @@ class CF7_Propstack_API
     }
 
     /**
+     * Get properties/units from Propstack
+     */
+    public function get_properties()
+    {
+        if (empty($this->api_key)) {
+            $this->log_error('API key not configured');
+            return array();
+        }
+
+        $endpoint = $this->api_url . '/units';
+
+        $response = $this->make_request('GET', $endpoint);
+
+        if ($response && is_array($response)) {
+            return $response;
+        }
+
+        return array();
+    }
+
+    /**
+     * Create a task in Propstack
+     */
+    public function create_task($task_data)
+    {
+        if (empty($this->api_key)) {
+            $this->log_error('API key not configured');
+            return false;
+        }
+
+        $endpoint = $this->api_url . '/tasks';
+
+        $request_data = array(
+            'task' => $task_data
+        );
+
+        $response = $this->make_request('POST', $endpoint, $request_data);
+
+        if ($response && isset($response['id'])) {
+            $this->log_success('Task created successfully with ID: ' . $response['id']);
+            return $response['id'];
+        }
+
+        $this->log_error('Failed to create task: ' . json_encode($response));
+        return false;
+    }
+
+    /**
      * Make HTTP request to Propstack API
      */
     private function make_request($method, $endpoint, $data = null)

--- a/includes/class-propstack-api.php
+++ b/includes/class-propstack-api.php
@@ -222,6 +222,41 @@ class CF7_Propstack_API
     }
 
     /**
+     * Get projects from Propstack
+     */
+    public function get_projects()
+    {
+        if (empty($this->api_key)) {
+            $this->debug_log('API key not configured for projects');
+            return array();
+        }
+
+        $endpoint = $this->api_url . '/projects';
+        $this->debug_log('Attempting to fetch projects from: ' . $endpoint);
+        
+        $response = $this->make_request('GET', $endpoint);
+        
+        $this->debug_log('Projects API response: ' . json_encode($response));
+
+        if ($response) {
+            // Handle different response formats
+            if (is_array($response)) {
+                $this->debug_log('Projects fetched successfully: ' . count($response) . ' projects');
+                return $response;
+            } elseif (isset($response['data']) && is_array($response['data'])) {
+                $this->debug_log('Projects fetched from data field: ' . count($response['data']) . ' projects');
+                return $response['data'];
+            } elseif (isset($response['projects']) && is_array($response['projects'])) {
+                $this->debug_log('Projects fetched from projects field: ' . count($response['projects']) . ' projects');
+                return $response['projects'];
+            }
+        }
+
+        $this->debug_log('Projects response was not in expected format or was empty');
+        return array();
+    }
+
+    /**
      * Create a task in Propstack
      */
     public function create_task($task_data)


### PR DESCRIPTION
Add optional Propstack task creation after CF7 submissions, configurable per form with property and client source selection.

This feature allows users to automatically create follow-up tasks in Propstack when a new contact signs up via a Contact Form 7 form, linking the task to relevant properties and client sources.

---
<a href="https://cursor.com/background-agent?bcId=bc-84d2266b-a27e-43bf-be5c-f390d59961c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84d2266b-a27e-43bf-be5c-f390d59961c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

