### PR TITLE
Add page URL tracking to Propstack custom field

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -71,6 +71,14 @@ class CF7_Propstack_Admin
             'cf7_propstack_settings',
             'cf7_propstack_general'
         );
+
+        add_settings_field(
+            'page_url_custom_field',
+            __('Page URL Custom Field', 'cf7-propstack-integration'),
+            array($this, 'page_url_custom_field_callback'),
+            'cf7_propstack_settings',
+            'cf7_propstack_general'
+        );
     }
 
     /**
@@ -82,6 +90,7 @@ class CF7_Propstack_Admin
 
         $sanitized['api_key'] = sanitize_text_field($input['api_key']);
         $sanitized['debug_mode'] = isset($input['debug_mode']) ? true : false;
+        $sanitized['page_url_custom_field'] = isset($input['page_url_custom_field']) ? sanitize_text_field($input['page_url_custom_field']) : '';
 
         return $sanitized;
     }
@@ -117,6 +126,27 @@ class CF7_Propstack_Admin
     ?>
         <input type="checkbox" id="debug_mode" name="cf7_propstack_options[debug_mode]" <?php checked($debug_mode); ?> />
         <label for="debug_mode"><?php _e('Enable debug mode for logging API requests', 'cf7-propstack-integration'); ?></label>
+    <?php
+    }
+
+    /**
+     * Page URL custom field callback
+     */
+    public function page_url_custom_field_callback()
+    {
+        $options = get_option('cf7_propstack_options');
+        $selected = isset($options['page_url_custom_field']) ? $options['page_url_custom_field'] : '';
+        $custom_fields = $this->get_cached_custom_fields();
+    ?>
+        <select id="page_url_custom_field" name="cf7_propstack_options[page_url_custom_field]">
+            <option value=""><?php _e('— Disabled —', 'cf7-propstack-integration'); ?></option>
+            <?php foreach ($custom_fields as $field_key => $field_label): ?>
+                <option value="<?php echo esc_attr($field_key); ?>" <?php selected($selected, $field_key); ?>>
+                    <?php echo esc_html($field_label); ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+        <p class="description"><?php _e('Select a Propstack custom field to automatically store the page URL where the form was submitted.', 'cf7-propstack-integration'); ?></p>
     <?php
     }
 

--- a/includes/class-integration-handler.php
+++ b/includes/class-integration-handler.php
@@ -777,6 +777,23 @@ class CF7_Propstack_Integration_Handler
             return;
         }
 
+        // Inject page URL into configured custom field
+        $options = get_option('cf7_propstack_options');
+        if (!empty($options['page_url_custom_field']) && !empty($_SERVER['HTTP_REFERER'])) {
+            $page_url = esc_url_raw($_SERVER['HTTP_REFERER']);
+            $custom_field_key = $options['page_url_custom_field'];
+            // Strip 'custom_' prefix for the API payload
+            if (strpos($custom_field_key, 'custom_') === 0) {
+                $custom_field_name = substr($custom_field_key, 7);
+            } else {
+                $custom_field_name = $custom_field_key;
+            }
+            if (!isset($contact_data['custom_fields'])) {
+                $contact_data['custom_fields'] = array();
+            }
+            $contact_data['custom_fields'][$custom_field_name] = $page_url;
+        }
+
         // Validate contact data
         $validation_errors = $this->api->validate_contact_data($contact_data);
         if (!empty($validation_errors)) {


### PR DESCRIPTION
## Summary
- Adds a "Page URL Custom Field" dropdown to the global Propstack settings page, populated with Propstack custom fields
- On form submission, automatically captures the page URL (via HTTP_REFERER) and sends it to the selected custom field in Propstack
- Allows tracking which page/property listing generated each contact inquiry

## Test plan
- [ ] Go to Contact Form 7 > Propstack settings — verify the new "Page URL Custom Field" dropdown appears with custom fields from Propstack
- [ ] Select a custom field and save settings
- [ ] Submit a CF7 form with Propstack enabled from a specific page
- [ ] Verify in Propstack that the contact's custom field contains the correct page URL
- [ ] Test with the setting set to "— Disabled —" to confirm no URL is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)